### PR TITLE
reroute create/new for all tags

### DIFF
--- a/app/controllers/appointments_controller.rb
+++ b/app/controllers/appointments_controller.rb
@@ -37,6 +37,6 @@ class AppointmentsController < ApplicationController
   private 
 
   def appointment_params
-    params.require(:appointment).permit(:title, :start_time, :end_time, :content, :poster_id, :location_list, :cuisine_list, :price_list, price_selects: [], location_selects: [], cuisine_selects: [])
+    params.require(:appointment).permit(:title, :start_time, :end_time, :content, :poster_id, price_selects: [], location_selects: [], cuisine_selects: [])
   end
 end

--- a/app/controllers/cuisines_controller.rb
+++ b/app/controllers/cuisines_controller.rb
@@ -2,6 +2,7 @@ class CuisinesController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @cuisine = Cuisine.new
     @cuisines = Cuisine.all
   end
 

--- a/app/controllers/cuisines_controller.rb
+++ b/app/controllers/cuisines_controller.rb
@@ -9,6 +9,19 @@ class CuisinesController < ApplicationController
     @cuisine = Cuisine.find(params[:id])
   end
 
+  def new
+    @cuisine = Cuisine.new
+  end
+
+  def create
+    @cuisine = Cuisine.new(cuisine_params)
+    if @cuisine.save
+      redirect_to cuisines_path
+    else
+      render :new
+    end
+  end
+
   def edit 
     @cuisine = Cuisine.find(params[:id])
   end

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -2,6 +2,7 @@ class LocationsController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @location = Location.new
     @locations = Location.all
   end
 

--- a/app/controllers/locations_controller.rb
+++ b/app/controllers/locations_controller.rb
@@ -9,6 +9,20 @@ class LocationsController < ApplicationController
     @location = Location.find(params[:id])
   end
 
+  def new
+    @location = Location.new
+  end
+
+  def create
+    @location = Location.new(location_params)
+    if @location.save
+      redirect_to locations_path
+    else
+      render :new
+    end
+  end
+
+
   def edit 
     @location = Location.find(params[:id])
   end

--- a/app/controllers/prices_controller.rb
+++ b/app/controllers/prices_controller.rb
@@ -9,6 +9,20 @@ class PricesController < ApplicationController
     @price = Price.find(params[:id])
   end
 
+
+  def new
+    @price = Price.new
+  end
+
+  def create
+    @price = Price.new(price_params)
+    if @price.save
+      redirect_to prices_path
+    else
+      render :new
+    end
+  end
+
   def edit 
     @price = Price.find(params[:id])
   end

--- a/app/controllers/prices_controller.rb
+++ b/app/controllers/prices_controller.rb
@@ -2,6 +2,7 @@ class PricesController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @price = Price.new
     @prices = Price.all
   end
 

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -14,71 +14,8 @@ class Appointment < ApplicationRecord
   has_many :locations, through: :appt_locations, dependent: :destroy
 
   validates :content, presence: true, length: { minimum: 8}
-  validates :location_selects, presence: true
-  validates :price_selects, presence: true
-  validates :cuisine_selects, presence: true
-
-  def cuisine_selects
-    cuisines.join(", ")
-  end
-
-  def cuisine_selects=(cuisines_array)
-    no_empty_string = cuisines_array.reject { |c| c.empty? }
-    cuisine_parse = no_empty_string.collect{|s| s.strip.downcase}.uniq
-    new_or_found_cuisines = cuisine_parse.collect { |name| Cuisine.find_or_create_by(name: name) }
-    self.cuisines = new_or_found_cuisines
-  end
-
-  # def cuisine_list
-  #   cuisines.join(", ")
-  # end
-
-  # def cuisine_list=(cuisines_string)
-  #   cuisine_names = cuisines_string.split(",").collect{|s| s.strip.downcase}.uniq
-  #   new_or_found_cuisines = cuisine_names.collect { |name| Cuisine.find_or_create_by(name: name) }
-  #   self.cuisines += new_or_found_cuisines
-  # end
-
-  def price_selects
-    prices.join(", ")
-  end
-
-  def price_selects=(prices_array)
-    no_empty_string = prices_array.reject { |p| p.empty? }
-    price_parse = no_empty_string.collect{|s| s.strip.downcase}.uniq
-    new_or_found_prices = price_parse.collect { |name| Price.find_or_create_by(name: name) }
-    self.prices = new_or_found_prices
-  end
-
-  # def price_list
-  #   prices.join(", ")
-  # end
-
-  # def price_list=(prices_string)
-  #   price_names = prices_string.split(",").collect{|s| s.strip.downcase}.uniq
-  #   new_or_found_prices = price_names.collect { |name| Price.find_or_create_by(name: name) }
-  #   self.prices += new_or_found_prices
-  # end
-
-  def location_selects
-    locations.join(", ")
-  end
-
-  def location_selects=(locations_array)
-    no_empty_string = locations_array.reject { |l| l.empty? }
-    location_parse = no_empty_string.collect{|s| s.strip.downcase}.uniq
-    new_or_found_locations = location_parse.collect { |name| Location.find_or_create_by(name: name) }
-    self.locations = new_or_found_locations
-  end
-
-  # def location_list
-  #   locations.join(", ")
-  # end
-
-  # def location_list=(locations_string)
-  #   location_names = locations_string.split(",").collect{|s| s.strip.downcase}.uniq
-  #   new_or_found_locations = location_names.collect { |name| Location.find_or_create_by(name: name) }
-  #   self.locations += new_or_found_locations
-  # end
+  validates :location_ids, presence: true
+  validates :price_ids, presence: true
+  validates :cuisine_ids, presence: true
 
 end

--- a/app/models/appointment.rb
+++ b/app/models/appointment.rb
@@ -26,18 +26,18 @@ class Appointment < ApplicationRecord
     no_empty_string = cuisines_array.reject { |c| c.empty? }
     cuisine_parse = no_empty_string.collect{|s| s.strip.downcase}.uniq
     new_or_found_cuisines = cuisine_parse.collect { |name| Cuisine.find_or_create_by(name: name) }
-    self.cuisines += new_or_found_cuisines
+    self.cuisines = new_or_found_cuisines
   end
 
-  def cuisine_list
-    cuisines.join(", ")
-  end
+  # def cuisine_list
+  #   cuisines.join(", ")
+  # end
 
-  def cuisine_list=(cuisines_string)
-    cuisine_names = cuisines_string.split(",").collect{|s| s.strip.downcase}.uniq
-    new_or_found_cuisines = cuisine_names.collect { |name| Cuisine.find_or_create_by(name: name) }
-    self.cuisines += new_or_found_cuisines
-  end
+  # def cuisine_list=(cuisines_string)
+  #   cuisine_names = cuisines_string.split(",").collect{|s| s.strip.downcase}.uniq
+  #   new_or_found_cuisines = cuisine_names.collect { |name| Cuisine.find_or_create_by(name: name) }
+  #   self.cuisines += new_or_found_cuisines
+  # end
 
   def price_selects
     prices.join(", ")
@@ -47,18 +47,18 @@ class Appointment < ApplicationRecord
     no_empty_string = prices_array.reject { |p| p.empty? }
     price_parse = no_empty_string.collect{|s| s.strip.downcase}.uniq
     new_or_found_prices = price_parse.collect { |name| Price.find_or_create_by(name: name) }
-    self.prices += new_or_found_prices
+    self.prices = new_or_found_prices
   end
 
-  def price_list
-    prices.join(", ")
-  end
+  # def price_list
+  #   prices.join(", ")
+  # end
 
-  def price_list=(prices_string)
-    price_names = prices_string.split(",").collect{|s| s.strip.downcase}.uniq
-    new_or_found_prices = price_names.collect { |name| Price.find_or_create_by(name: name) }
-    self.prices += new_or_found_prices
-  end
+  # def price_list=(prices_string)
+  #   price_names = prices_string.split(",").collect{|s| s.strip.downcase}.uniq
+  #   new_or_found_prices = price_names.collect { |name| Price.find_or_create_by(name: name) }
+  #   self.prices += new_or_found_prices
+  # end
 
   def location_selects
     locations.join(", ")
@@ -68,17 +68,17 @@ class Appointment < ApplicationRecord
     no_empty_string = locations_array.reject { |l| l.empty? }
     location_parse = no_empty_string.collect{|s| s.strip.downcase}.uniq
     new_or_found_locations = location_parse.collect { |name| Location.find_or_create_by(name: name) }
-    self.locations += new_or_found_locations
+    self.locations = new_or_found_locations
   end
 
-  def location_list
-    locations.join(", ")
-  end
+  # def location_list
+  #   locations.join(", ")
+  # end
 
-  def location_list=(locations_string)
-    location_names = locations_string.split(",").collect{|s| s.strip.downcase}.uniq
-    new_or_found_locations = location_names.collect { |name| Location.find_or_create_by(name: name) }
-    self.locations += new_or_found_locations
-  end
+  # def location_list=(locations_string)
+  #   location_names = locations_string.split(",").collect{|s| s.strip.downcase}.uniq
+  #   new_or_found_locations = location_names.collect { |name| Location.find_or_create_by(name: name) }
+  #   self.locations += new_or_found_locations
+  # end
 
 end

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -25,13 +25,13 @@
   </div>
 
   <div class="form-row mt-3">
-    <%= f.collection_select(:cuisine_selects, Cuisine.all, :name, :name, {:prompt => "Choose Cuisine(s)"},{:multiple => true, :required => true, :class => "custom-select"}) %>
+    <%= f.collection_select(:cuisine_ids, Cuisine.all, :id, :name, {:prompt => "Choose Cuisine(s)"},{:multiple => true, :required => true, :class => "custom-select"}) %>
   </div>
   <div class="form-row mt-3">
-    <%= f.collection_select(:location_selects, Location.all, :name, :name, {:prompt => "Choose Location(s)"},{:multiple => true, :required => true, :class => "custom-select"}) %>
+    <%= f.collection_select(:location_ids, Location.all, :id, :name, {:prompt => "Choose Location(s)"},{:multiple => true, :required => true, :class => "custom-select"}) %>
   </div>
   <div class="form-row mt-3">
-    <%= f.collection_select(:price_selects, Price.all, :name, :name, {:prompt => "Choose Price range"},{:multiple => true, :required => true, :class => "custom-select"}) %>
+    <%= f.collection_select(:price_ids, Price.all, :id, :name, {:prompt => "Choose Price range"},{:multiple => true, :required => true, :class => "custom-select"}) %>
   </div>
 
   <div class=“form-row”>

--- a/app/views/appointments/new.html.erb
+++ b/app/views/appointments/new.html.erb
@@ -33,22 +33,6 @@
   <div class="form-row mt-3">
     <%= f.collection_select(:price_selects, Price.all, :name, :name, {:prompt => "Choose Price range"},{:multiple => true, :required => true, :class => "custom-select"}) %>
   </div>
-  
-  <% if @user.isAdmin %>
-    <div class="form-group mt-3 text-left">
-      <%= f.label :cuisine_list, "Add cuisine" %>
-      <%= f.text_field :cuisine_list, class: "form-control" %>
-    </div>
-    <div class="form-group mt-3 text-left">
-      <%= f.label :location_list, "Add location" %>
-      <%= f.text_field :location_list, class: "form-control" %>
-    </div>
-    <div class="form-group mt-3 text-left">
-      <%= f.label :price_list , "Add price range" %>
-      <%= f.text_field :price_list, class: "form-control" %>
-    </div>
-  <% end %>
-
 
   <div class=“form-row”>
     <%= f.submit "Create appointment", class: "btn btn-success mt-3" %>

--- a/app/views/cuisines/index.html.erb
+++ b/app/views/cuisines/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="text-center">All cuisines</h1>
- <% if @user.isAdmin %>
+ <% if current_user.isAdmin %>
     <div class="form-group mt-3 text-left">
     <%= form_for @cuisine do |f| %>
       <%= f.label :name, "Add cuisine" %>

--- a/app/views/cuisines/index.html.erb
+++ b/app/views/cuisines/index.html.erb
@@ -1,5 +1,15 @@
 <h1 class="text-center">All cuisines</h1>
-
+ <% if @user.isAdmin %>
+    <div class="form-group mt-3 text-left">
+    <%= form_for @cuisine do |f| %>
+      <%= f.label :name, "Add cuisine" %>
+      <%= f.text_field :name, class: "form-control" %>
+    </div>
+    <div class="form-group mt-3 text-left">
+     <%= f.submit "Save", class: "btn btn-success mt-3" %>
+    </div>
+    <% end %>
+  <% end %>
 <div class="row d-flex flex-wrap">
 <% @cuisines.each do |cuisine| %>
   <div class="border col-3 p-2 mx-1 text-center">

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,5 +1,17 @@
 <h1 class="text-center">All locations</h1>
+  <% if @user.isAdmin %>
+    <div class="form-group mt-3 text-left">
+    <%= form_for @location do |f| %>
+      <%= f.label :name, "Add location" %>
+      <%= f.text_field :name, class: "form-control" %>
+    </div>
+    <div class="form-group mt-3 text-left">
+     <%= f.submit "Save", class: "btn btn-success mt-3" %>
+    </div>
+    <% end %>
+  <% end %>
 <div class="row d-flex flex-wrap">
+
 <% @locations.each do |location| %>
   <div class="border col-2 p-2 mx-1 text-center">
     <%= link_to location.name, location_path(location) %>

--- a/app/views/locations/index.html.erb
+++ b/app/views/locations/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="text-center">All locations</h1>
-  <% if @user.isAdmin %>
+  <% if current_user.isAdmin %>
     <div class="form-group mt-3 text-left">
     <%= form_for @location do |f| %>
       <%= f.label :name, "Add location" %>

--- a/app/views/prices/index.html.erb
+++ b/app/views/prices/index.html.erb
@@ -1,5 +1,5 @@
 <h1 class="text-center">All price ranges</h1>
-  <% if @user.isAdmin %>
+  <% if current_user.isAdmin %>
     <div class="form-group mt-3 text-left">
     <%= form_for @price do |f| %>
       <%= f.label :name, "Add price range" %>

--- a/app/views/prices/index.html.erb
+++ b/app/views/prices/index.html.erb
@@ -1,5 +1,15 @@
 <h1 class="text-center">All price ranges</h1>
-
+  <% if @user.isAdmin %>
+    <div class="form-group mt-3 text-left">
+    <%= form_for @price do |f| %>
+      <%= f.label :name, "Add price range" %>
+      <%= f.text_field :name, class: "form-control" %>
+    </div>
+    <div class="form-group mt-3 text-left">
+     <%= f.submit "Save", class: "btn btn-success mt-3" %>
+    </div>
+    <% end %>
+  <% end %>
 <div class="row d-flex flex-wrap">
 <% @prices.each do |price| %>
   <div class="border col-3 p-2 mx-1 text-center">

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,20 +8,25 @@
 
 User.create(firstname: 'Default', lastname: 'User', username: 'Admin', phone: '12345678', isAdmin: true, email: 'admin@email.com', password: 'password')
 
-Appointment.create(title: 'Looking for a lunch buddy!', poster_id: 1, status: 0, start_time: DateTime.new(2020,9,14,11), end_time: DateTime.new(2020,9,14,12), content:'Wanna share good food and good conversations!', cuisine_list: "mexican", location_list: 'cbd', price_list: '<$5')
-
-Appointment.create(title: 'Come dine with me', poster_id: 1, status: 0, start_time: DateTime.new(2020,9,15,12), end_time: DateTime.new(2020,9,15,13), content:'I want to expand my palate. Join me on a food adventure!', cuisine_list: "halal", location_list: 'cbd', price_list: '<$5')
-
-
+Location.create(name: 'cbd')
 Location.create(name: 'west')
 Location.create(name: 'east')
 Location.create(name: 'northeast')
 
 Cuisine.create(name: 'chinese')
+Cuisine.create(name: 'halal')
+Cuisine.create(name: 'mexican')
 
+Price.create(name: '<$5')
 Price.create(name: '<$10')
 Price.create(name: '<$20')
 Price.create(name: '<$30')
 Price.create(name: '<$40')
 Price.create(name: '<$50')
 Price.create(name: '$50++')
+
+Appointment.create(title: 'Looking for a lunch buddy!', poster_id: 1, status: 0, start_time: DateTime.new(2020,9,14,11), end_time: DateTime.new(2020,9,14,12), content:'Wanna share good food and good conversations!', cuisine_ids: [1], location_ids: [1], price_ids: [1])
+
+Appointment.create(title: 'Come dine with me', poster_id: 1, status: 0, start_time: DateTime.new(2020,9,15,12), end_time: DateTime.new(2020,9,15,13), content:'I want to expand my palate. Join me on a food adventure!', cuisine_ids: [2], location_ids: [2], price_ids: [2])
+
+


### PR DESCRIPTION
Changes:
-  move create/new for all tags to <tags>/index instead
- remove <tag_list> field from appt form 
- remove <tag_list> methods from appt model
- update validation from <tag_selects> to <tag_ids> in appt model
- update tag controllers from <tag_selects> to <tag_ids>
-update tags in seeds  from <tag_selects> to <tag_ids>